### PR TITLE
Change casing from livescript to LiveScript

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ var extensions = {
   '.js': null,
   '.json': null,
   '.litcoffee': 'coffee-script/register',
-  '.ls': 'livescript',
+  '.ls': 'LiveScript',
   '.toml': 'toml-require',
   '.xml': 'require-xml',
   '.yaml': 'require-yaml',


### PR DESCRIPTION
Hi.

Interpret currently fails at loading LiveScript files because of the (unfortunate) casing of the module :
https://www.npmjs.org/package/livescript vs https://www.npmjs.org/package/LiveScript

Bug found while attending to load a gulpfile in ls.
