### PR TITLE
Support using babel 7 for `.ts`, `.tsx`, and new `.babel.ts` (fixes #48)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,6 @@ Map file types to modules which provide a [require.extensions] loader.
       module: 'babel-register',
       register: function (module) {
         module({
-          // register on .js extension due to https://github.com/joyent/node/blob/v0.12.0/lib/module.js#L353
-          // which only captures the final extension (.babel.js -> .js)
           extensions: '.js'
         });
       }
@@ -47,6 +45,16 @@ Map file types to modules which provide a [require.extensions] loader.
       register: function (module) {
         module({
           extensions: '.js'
+        });
+      }
+    }
+  ],
+  '.babel.ts': [
+    {
+      module: '@babel/register',
+      register: function (module) {
+        module({
+          extensions: '.ts'
         });
       }
     }
@@ -118,8 +126,32 @@ Map file types to modules which provide a [require.extensions] loader.
       module.install();
     }
   },
-  '.ts': ['ts-node/register', 'typescript-node/register', 'typescript-register', 'typescript-require'],
-  '.tsx': ['ts-node/register', 'typescript-node/register'],
+  '.ts': [
+    'ts-node/register',
+    'typescript-node/register',
+    'typescript-register',
+    'typescript-require',
+    {
+      module: '@babel/register',
+      register: function (module) {
+        module({
+          extensions: '.ts'
+        });
+      }
+    }
+  ],
+  '.tsx': [
+    'ts-node/register',
+    'typescript-node/register',
+    {
+      module: '@babel/register',
+      register: function (module) {
+        module({
+          extensions: '.tsx'
+        });
+      }
+    }
+  ],
   '.wisp': 'wisp/engine/node',
   '.xml': 'require-xml',
   '.yaml': 'require-yaml',

--- a/index.js
+++ b/index.js
@@ -14,8 +14,6 @@ const extensions = {
       module: 'babel-register',
       register: function (module) {
         module({
-          // register on .js extension due to https://github.com/joyent/node/blob/v0.12.0/lib/module.js#L353
-          // which only captures the final extension (.babel.js -> .js)
           extensions: '.js'
         });
       }
@@ -33,6 +31,16 @@ const extensions = {
       register: function (module) {
         module({
           extensions: '.js'
+        });
+      }
+    }
+  ],
+  '.babel.ts': [
+    {
+      module: '@babel/register',
+      register: function (module) {
+        module({
+          extensions: '.ts'
         });
       }
     }
@@ -104,8 +112,32 @@ const extensions = {
       module.install();
     }
   },
-  '.ts': ['ts-node/register', 'typescript-node/register', 'typescript-register', 'typescript-require'],
-  '.tsx': ['ts-node/register', 'typescript-node/register'],
+  '.ts': [
+    'ts-node/register',
+    'typescript-node/register',
+    'typescript-register',
+    'typescript-require',
+    {
+      module: '@babel/register',
+      register: function (module) {
+        module({
+          extensions: '.ts'
+        });
+      }
+    }
+  ],
+  '.tsx': [
+    'ts-node/register',
+    'typescript-node/register',
+    {
+      module: '@babel/register',
+      register: function (module) {
+        module({
+          extensions: '.tsx'
+        });
+      }
+    }
+  ],
   '.wisp': 'wisp/engine/node',
   '.xml': 'require-xml',
   '.yaml': 'require-yaml',
@@ -115,6 +147,7 @@ const extensions = {
 const jsVariantExtensions = [
   '.js',
   '.babel.js',
+  '.babel.ts',
   '.buble.js',
   '.cirru',
   '.cjsx',
@@ -129,6 +162,7 @@ const jsVariantExtensions = [
   '.liticed',
   '.ls',
   '.ts',
+  '.tsx',
   '.wisp'
 ];
 


### PR DESCRIPTION
Fixes #48 

## Approach

Use babel only as a fallback for `.ts`, `.tsx` since:
- babel must be configured with the new in babel 7 typescript
  transform,
- the babel typescript transform does not perform type-checking, and
- it is plausible that both `ts-node` is expected to be used for `.ts`
  and `@babel/register` to be used for `.babel.js`.

The new `.babel.ts` should only be needed as an escape hatch if
`ts-node` is present, but babel is preferred for `interpret`; for
example:

- `"deploy": "ts-node scripts/deploy.ts"` in package.json scripts and
- `webpackfile.babel.ts`, where babel is preferred.

## Possible issues

I believe this won't add any breaking changes that are not both very rare and easily fixable, but adding an entry for "escape-hatch" purposes is new, it looks like.

For that, I'm wondering if this should also add `.babel.tsx`, for completion and to avoid possible confusion in rare cases, given that `.babel.js` exists and `.babel.jsx` doesn't simply because `.jsx` already obviously needs transform.

Another issue is that since `extensions` only includes `.ts` for `.ts` and `.tsx` for `.tsx` this means that a `.ts` file compiled with babel 7 can't import a `.tsx` file (and vice-versa), unlike with `ts-node`. On the other hand, I was simply following the pattern of `.babel.js` and `.jsx`, and apparently this hasn't been an issue so far.

## Drive-by fixes

#47 duplicated the comment on `extensions`, which was previously only on the first case. Just moved it up.

`jsVariantExtensions` included `.babel.js`, `.jsx` and `.ts`, but not `.tsx`, so I added that when I added `.babel.ts`.

## Testing

I already had a repository set up with a `webpackfile.ts` wrapped with a `webpackfile.js`:

```js
require('@babel/register');
module.exports = require('./webpackfile.ts');
```

I updated this project to use this fork by adding `"resolutions": { "interpret": "link:../js-interpret" }` to the `package.json` and deleted the `webpackfile.js`, and webpack still worked, and a console.log in `.babelrc.js` gets echoed.

Adding a type error to `webpackfile.ts` (`const x: string = 0`) does _not_ cause a failure when running `webpack` (since babel doesn't do type checking).

I then added `ts-node` to the dependencies and the type error was then reported as expected.

I then renamed the config file to `webpackfile.babel.ts` and babel was used again.