### PR TITLE
Disable ts-node typechecking

### DIFF
--- a/index.js
+++ b/index.js
@@ -104,8 +104,22 @@ const extensions = {
       module.install();
     }
   },
-  '.ts': ['ts-node/register', 'typescript-node/register', 'typescript-register', 'typescript-require'],
-  '.tsx': ['ts-node/register', 'typescript-node/register'],
+  '.ts': [{
+      module: 'ts-node/register',
+      register: function (module) {
+        module.register({
+          transpileOnly: true // fast transpile, rather than full typecheck
+        });
+      }
+    }, 'typescript-node/register', 'typescript-register', 'typescript-require'],
+  '.tsx': [{
+      module: 'ts-node/register',
+      register: function (module) {
+        module.register({
+          transpileOnly: true // fast transpile, rather than full typecheck
+        });
+      }
+    }, 'typescript-node/register'],
   '.wisp': 'wisp/engine/node',
   '.xml': 'require-xml',
   '.yaml': 'require-yaml',


### PR DESCRIPTION
When, eg, `gulp` uses `interpret` to load a `Gulpfile.ts`, `ts-node` will search the containing directory for _all_ `.ts` files to run a typechecking pass on all of them (as of version `6`) (instead of a module compilation with a root of the required file) - this is hugely unnecessary, and adversely impacts `gulp` startup time when using a `.ts` file (to the point where, in TS internally, we crash `node` because we have hundreds of MB of `.ts` in our test subrepos). By simply disabling the typecheck pass (and only using the fast-transpile behavior), startup returns to pre-`ts-node`-`6` performance.

cc @blakeembrey for opinons, ref https://github.com/Microsoft/TypeScript/issues/23479