### PR TITLE
Ignore files not ending by .babel.[tj]s(x) and add upward-optional root mode for babel 7 register

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,29 +1,49 @@
+var path = require('path');
+
+var endsInBabelJs = /\.babel\.[jt]s(x)$/;
+
+function ignoreNonBabelAndNodeModules(file) {
+  return !endsInBabelJs.test(file) &&
+    path.relative(process.cwd(), file).split(path.sep).indexOf('node_modules') >= 0;
+}
+
 var extensions = {
   '.babel.js': [
     {
       module: '@babel/register',
       register: function(hook) {
-        // register on .js extension due to https://github.com/joyent/node/blob/v0.12.0/lib/module.js#L353
-        // which only captures the final extension (.babel.js -> .js)
-        hook({ extensions: '.js' });
+        hook({
+          extensions: '.js',
+          rootMode: 'upward-optional',
+          ignore: [ignoreNonBabelAndNodeModules],
+        });
       },
     },
     {
       module: 'babel-register',
       register: function(hook) {
-        hook({ extensions: '.js' });
+        hook({
+          extensions: '.js',
+          ignore: ignoreNonBabelAndNodeModules,
+        });
       },
     },
     {
       module: 'babel-core/register',
       register: function(hook) {
-        hook({ extensions: '.js' });
+        hook({
+          extensions: '.js',
+          ignore: ignoreNonBabelAndNodeModules,
+        });
       },
     },
     {
       module: 'babel/register',
       register: function(hook) {
-        hook({ extensions: '.js' });
+        hook({
+          extensions: '.js',
+          ignore: ignoreNonBabelAndNodeModules,
+        });
       },
     },
   ],
@@ -31,7 +51,11 @@ var extensions = {
     {
       module: '@babel/register',
       register: function(hook) {
-        hook({ extensions: '.ts' });
+        hook({
+          extensions: '.ts',
+          rootMode: 'upward-optional',
+          ignore: [ignoreNonBabelAndNodeModules],
+        });
       },
     },
   ],
@@ -62,25 +86,38 @@ var extensions = {
     {
       module: '@babel/register',
       register: function(hook) {
-        hook({ extensions: '.jsx' });
+        hook({
+          extensions: '.jsx',
+          rootMode: 'upward-optional',
+          ignore: [ignoreNonBabelAndNodeModules],
+        });
       },
     },
     {
       module: 'babel-register',
       register: function(hook) {
-        hook({ extensions: '.jsx' });
+        hook({
+          extensions: '.jsx',
+          ignore: ignoreNonBabelAndNodeModules,
+        });
       },
     },
     {
       module: 'babel-core/register',
       register: function(hook) {
-        hook({ extensions: '.jsx' });
+        hook({
+          extensions: '.jsx',
+          ignore: ignoreNonBabelAndNodeModules,
+        });
       },
     },
     {
       module: 'babel/register',
       register: function(hook) {
-        hook({ extensions: '.jsx' });
+        hook({
+          extensions: '.jsx',
+          ignore: ignoreNonBabelAndNodeModules,
+        });
       },
     },
     {
@@ -108,7 +145,11 @@ var extensions = {
     {
       module: '@babel/register',
       register: function(hook) {
-        hook({ extensions: '.ts' });
+        hook({
+          extensions: '.ts',
+          rootMode: 'upward-optional',
+          ignore: [ignoreNonBabelAndNodeModules],
+        });
       },
     },
   ],
@@ -118,7 +159,11 @@ var extensions = {
     {
       module: '@babel/register',
       register: function(hook) {
-        hook({ extensions: '.tsx' });
+        hook({
+          extensions: '.tsx',
+          rootMode: 'upward-optional',
+          ignore: [ignoreNonBabelAndNodeModules],
+        });
       },
     },
   ],

--- a/test/index.js
+++ b/test/index.js
@@ -60,7 +60,7 @@ var minVersions = {
   'require-xml': { major: 6, minor: 0 },
 };
 
-describe('interpret.extenstions', function() {
+describe('interpret.extensions', function() {
 
   beforeEach(cleanup);
 


### PR DESCRIPTION
Let's start this PR by a quote from a great man :

> Now that I've released v1.2 with babel7 and esm support, I'd like to revisit this and get it shipped in a 2.0 (along with the solution to #54). I'm definitely considering this breaking but I'm fine bumping to 2.0

So this PR aims to do that : 
- It bumps the version to 2.0
- It extends the #41 which ignores non babel file extensions (#41 aimed to fix #39) to everywhere babel is called. Including in the new @babel/register which takes an array of multiple type including function so I just passed to @babel/register the function I use as a property for "ignore" for the older babel-register 
- It should fix #54 which is a personnal problem for my project where I use webpack which depends on gulpjs/interpret package.