### PR TITLE
Update: Register both '.ts/.tsx' extensions for babel

### DIFF
--- a/index.js
+++ b/index.js
@@ -146,7 +146,7 @@ var extensions = {
       module: '@babel/register',
       register: function(hook) {
         hook({
-          extensions: '.ts',
+          extensions: ['.ts', '.tsx'],
           rootMode: 'upward-optional',
           ignore: [ignoreNonBabelAndNodeModules],
         });
@@ -160,7 +160,7 @@ var extensions = {
       module: '@babel/register',
       register: function(hook) {
         hook({
-          extensions: '.tsx',
+          extensions: ['.ts', '.tsx'],
           rootMode: 'upward-optional',
           ignore: [ignoreNonBabelAndNodeModules],
         });

--- a/test/fixtures/ts/4/.babelrc
+++ b/test/fixtures/ts/4/.babelrc
@@ -1,3 +1,7 @@
 {
-  "presets": ["@babel/preset-env", "@babel/preset-typescript"]
+  "presets": [
+    "@babel/preset-env",
+    "@babel/preset-react",
+    "@babel/preset-typescript"
+  ]
 }

--- a/test/fixtures/ts/4/component.tsx
+++ b/test/fixtures/ts/4/component.tsx
@@ -1,5 +1,3 @@
-import data from "./data"
-
 const React = {
   createElement(Component: () => any) {
     return Component()
@@ -17,4 +15,4 @@ const Component = () => {
 }
 
 // Test TSX syntax.
-export default <Component {...data} />
+export default <Component />

--- a/test/fixtures/ts/4/package.json
+++ b/test/fixtures/ts/4/package.json
@@ -2,6 +2,7 @@
   "dependencies": {
     "@babel/core": "^7.2.2",
     "@babel/preset-env": "^7.2.3",
+    "@babel/preset-react": "^7.0.0",
     "@babel/preset-typescript": "^7.1.0",
     "@babel/register": "^7.0.0"
   }

--- a/test/fixtures/ts/4/test.ts
+++ b/test/fixtures/ts/4/test.ts
@@ -1,11 +1,5 @@
-var test = {
-  data: {
-    trueKey: true,
-    falseKey: false,
-    subKey: {
-      subProp: 1
-    }
-  }
-};
+import Component from "./component"
 
-export default test;
+var test = { ...Component }
+
+export default test

--- a/test/fixtures/tsx/2/data.ts
+++ b/test/fixtures/tsx/2/data.ts
@@ -1,0 +1,11 @@
+var test = {
+  data: {
+    trueKey: true,
+    falseKey: false,
+    subKey: {
+      subProp: 1
+    }
+  }
+}
+
+export default test


### PR DESCRIPTION
Fix #61