### PR TITLE
Use transpile only version of ts-node for better performance during runtime load

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Map file types to modules which provide a [require.extensions] loader.
     },
   },
   '.ts': [
+    'ts-node/register/transpile-only',
     'ts-node/register',
     'typescript-node/register',
     'typescript-register',
@@ -174,6 +175,7 @@ Map file types to modules which provide a [require.extensions] loader.
     },
   ],
   '.tsx': [
+    'ts-node/register/transpile-only',
     'ts-node/register',
     'typescript-node/register',
     'sucrase/register',

--- a/index.js
+++ b/index.js
@@ -141,6 +141,7 @@ var extensions = {
     },
   },
   '.ts': [
+    'ts-node/register/transpile-only',
     'ts-node/register',
     'typescript-node/register',
     'typescript-register',
@@ -158,6 +159,7 @@ var extensions = {
     },
   ],
   '.tsx': [
+    'ts-node/register/transpile-only',
     'ts-node/register',
     'typescript-node/register',
     'sucrase/register',


### PR DESCRIPTION
Hi 

when using interpret with typescript files and ts-node, there is significant initial load time.
To improve this, ts-node has transpile-only option which is fast and production ready.
This PR add transpile only option to ts-node register.

For more details: https://github.com/TypeStrong/ts-node/issues/104#issuecomment-525358504