### PR TITLE
Travis-ci: added ppc64le support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+arch:
+  - amd64
+  - ppc64le
 sudo: false
 language: node_js
 node_js:
@@ -9,5 +12,10 @@ node_js:
   - '4'
   - '0.12'
   - '0.10'
+matrix:
+    allow_failures:
+       - node_js: '4'
+       - node_js: '0.12'
+       - node_js: '0.10'
 after_script:
   - npm run coveralls


### PR DESCRIPTION
Hi,
I have added support for ppc64le build on travis-ci in the branch . The travis-ci build log can be tracked on the link :https://travis-ci.com/github/sanjaymsh/interpret/builds/206978309 . I believe it is ready for the final review and merge.
Please have a look on it.

Thanks !!