### PR TITLE
Add support for swc

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,6 +19,11 @@ function ignoreNonBabelAndNodeModules(file) {
     path.relative(process.cwd(), file).split(path.sep).indexOf('node_modules') >= 0;
 }
 
+// Not part of the above check because it seems broken
+function isNodeModules(file) {
+  return path.relative(process.cwd(), file).split(path.sep).indexOf('node_modules') >= 0;
+}
+
 var extensions = {
   '.babel.js': [
     {
@@ -246,6 +251,16 @@ var extensions = {
         });
       },
     },
+    {
+      module: '@swc/register',
+      register: function(hook) {
+        hook({
+          extensions: '.ts',
+          only: [endsInTs],
+          ignore: [isNodeModules],
+        });
+      },
+    },
   ],
   '.tsx': [
     'ts-node/register',
@@ -270,6 +285,16 @@ var extensions = {
           hookMatcher: function(file) {
             return endsInTsx.test(file);
           },
+        });
+      },
+    },
+    {
+      module: '@swc/register',
+      register: function(hook) {
+        hook({
+          extensions: '.tsx',
+          only: [endsInTsx],
+          ignore: [isNodeModules],
         });
       },
     },

--- a/test/fixtures/ts/7/.swcrc
+++ b/test/fixtures/ts/7/.swcrc
@@ -1,0 +1,10 @@
+{
+  "jsc": {
+    "parser": {
+      "syntax": "typescript"
+    }
+  },
+  "module": {
+    "type": "commonjs"
+  }
+}

--- a/test/fixtures/ts/7/package.json
+++ b/test/fixtures/ts/7/package.json
@@ -1,0 +1,6 @@
+{
+  "dependencies": {
+    "@swc/core": "^1.2.110",
+    "@swc/register": "^0.1.7"
+  }
+}

--- a/test/fixtures/ts/7/test.ts
+++ b/test/fixtures/ts/7/test.ts
@@ -1,0 +1,15 @@
+var test = {
+  data: {
+    trueKey: true,
+    falseKey: false,
+    subKey: {
+      subProp: 1
+    }
+  }
+};
+
+var main = {
+  default: test
+};
+
+export = main;

--- a/test/fixtures/tsx/5/.swcrc
+++ b/test/fixtures/tsx/5/.swcrc
@@ -1,0 +1,11 @@
+{
+  "jsc": {
+    "parser": {
+      "syntax": "typescript",
+      "tsx": true
+    }
+  },
+  "module": {
+    "type": "commonjs"
+  }
+}

--- a/test/fixtures/tsx/5/package.json
+++ b/test/fixtures/tsx/5/package.json
@@ -1,0 +1,6 @@
+{
+  "dependencies": {
+    "@swc/core": "^1.2.110",
+    "@swc/register": "^0.1.7"
+  }
+}

--- a/test/fixtures/tsx/5/test.tsx
+++ b/test/fixtures/tsx/5/test.tsx
@@ -1,0 +1,18 @@
+const React = {
+  createElement(Component: () => any) {
+    return Component()
+  }
+}
+
+// Test harmony arrow functions.
+const Component = () => {
+  var trueKey: boolean = true
+  var falseKey: boolean = false
+  var subKey = { subProp: 1 }
+
+  // Test harmony object short notation.
+  return { data: { trueKey, falseKey, subKey } }
+};
+
+// Test TSX syntax.
+export default <Component />


### PR DESCRIPTION
Hey! This is a simple PR to add support for [swc](https://swc.rs/), since it is increasing in popularity and it's very fast! While it is supposed to be a drop-in replacement for babel, I only adding it on TypeScript extension as is what I more used to