### PR TITLE
Add .cjs as list of potential JS files

### DIFF
--- a/cjs-stub.js
+++ b/cjs-stub.js
@@ -1,0 +1,1 @@
+require.extensions['.cjs'] = null;

--- a/index.js
+++ b/index.js
@@ -109,6 +109,7 @@ var extensions = {
       });
     },
   },
+  '.cjs': null,
   '.coffee': 'coffeescript/register',
   '.coffee.md': 'coffeescript/register',
   '.esbuild.js': {
@@ -339,6 +340,7 @@ var jsVariantExtensions = [
   '.esbuild.jsx',
   '.esbuild.ts',
   '.esbuild.tsx',
+  '.cjs',
   '.coffee',
   '.coffee.md',
   '.esm.js',

--- a/index.js
+++ b/index.js
@@ -60,6 +60,7 @@ function endsInSwcTsx(filename) {
   return filename.endsWith('.swc.tsx');
 }
 
+var cjsStub = path.join(__dirname, 'cjs-stub');
 var mjsStub = path.join(__dirname, 'mjs-stub');
 
 function isNodeModules(file) {
@@ -109,7 +110,7 @@ var extensions = {
       });
     },
   },
-  '.cjs': null,
+  '.cjs': cjsStub,
   '.coffee': 'coffeescript/register',
   '.coffee.md': 'coffeescript/register',
   '.esbuild.js': {

--- a/test/fixtures/cjs/0/package.json
+++ b/test/fixtures/cjs/0/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/test/fixtures/cjs/0/rechoir.js
+++ b/test/fixtures/cjs/0/rechoir.js
@@ -1,0 +1,23 @@
+import assert from 'assert';
+import path from 'path';
+
+import rechoir from 'rechoir';
+import { extensions } from '../../../../index.js';
+
+var fixture = path.resolve('test.cjs');
+
+rechoir.prepare(extensions, fixture);
+
+const { default: result } = await import(fixture);
+
+const expected = {
+  data: {
+    trueKey: true,
+    falseKey: false,
+    subKey: {
+      subProp: 1,
+    },
+  },
+};
+
+assert.deepEqual(result, expected);

--- a/test/fixtures/cjs/0/rechoir.js
+++ b/test/fixtures/cjs/0/rechoir.js
@@ -1,5 +1,6 @@
 import assert from 'assert';
 import path from 'path';
+import url from 'url';
 
 import rechoir from 'rechoir';
 import { extensions } from '../../../../index.js';
@@ -8,7 +9,7 @@ var fixture = path.resolve('test.cjs');
 
 rechoir.prepare(extensions, fixture);
 
-const { default: result } = await import(fixture);
+const { default: result } = await import(url.pathToFileURL(fixture).href);
 
 const expected = {
   data: {

--- a/test/fixtures/cjs/0/test.cjs
+++ b/test/fixtures/cjs/0/test.cjs
@@ -1,0 +1,9 @@
+module.exports = {
+  data: {
+    trueKey: true,
+    falseKey: false,
+    subKey: {
+      subProp: 1,
+    },
+  },
+};

--- a/test/fixtures/cjs/1/package.json
+++ b/test/fixtures/cjs/1/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "commonjs"
+}

--- a/test/fixtures/cjs/1/rechoir.js
+++ b/test/fixtures/cjs/1/rechoir.js
@@ -1,0 +1,23 @@
+var assert = require('assert');
+var path = require('path');
+
+var rechoir = require('rechoir');
+var { extensions } = require('../../../../index.js');
+
+var fixture = path.resolve('test.cjs');
+
+rechoir.prepare(extensions, fixture);
+
+const result = require(fixture);
+
+const expected = {
+  data: {
+    trueKey: true,
+    falseKey: false,
+    subKey: {
+      subProp: 1,
+    },
+  },
+};
+
+assert.deepEqual(result, expected);

--- a/test/fixtures/cjs/1/test.cjs
+++ b/test/fixtures/cjs/1/test.cjs
@@ -1,0 +1,9 @@
+module.exports = {
+  data: {
+    trueKey: true,
+    falseKey: false,
+    subKey: {
+      subProp: 1,
+    },
+  },
+};

--- a/test/index.js
+++ b/test/index.js
@@ -275,12 +275,16 @@ describe('interpret.extensions', function () {
       this.skip();
     }
 
+    this.timeout(0);
+
     process.chdir(path.join(__dirname, 'fixtures/cjs/0'));
 
     child.exec('node rechoir.js', done);
   });
 
   it('does not error with the .cjs extension when inside a type: commonjs package', function (done) {
+    this.timeout(0);
+
     process.chdir(path.join(__dirname, 'fixtures/cjs/1'));
 
     child.exec('node rechoir.js', done);

--- a/test/index.js
+++ b/test/index.js
@@ -273,7 +273,10 @@ describe('interpret.extensions', function () {
   it('does not error with the .cjs extension when inside a type: module package', function (done) {
     process.chdir(path.join(__dirname, 'fixtures/cjs/0'));
 
-    child.exec('node --harmony-top-level-await --experimental-modules rechoir.js', done);
+    child.exec(
+      'node --harmony-top-level-await --experimental-modules rechoir.js',
+      done
+    );
   });
 
   it('does not error with the .cjs extension when inside a type: commonjs package', function (done) {

--- a/test/index.js
+++ b/test/index.js
@@ -271,6 +271,10 @@ describe('interpret.extensions', function () {
   });
 
   it('does not error with the .cjs extension when inside a type: module package', function (done) {
+    if (nodeVersion.major < 12) {
+      this.skip();
+    }
+
     process.chdir(path.join(__dirname, 'fixtures/cjs/0'));
 
     child.exec('node rechoir.js', done);

--- a/test/index.js
+++ b/test/index.js
@@ -271,12 +271,13 @@ describe('interpret.extensions', function () {
   });
 
   it('does not error with the .cjs extension when inside a type: module package', function (done) {
+    if (nodeVersion.major < 14) {
+      this.skip();
+    }
+
     process.chdir(path.join(__dirname, 'fixtures/cjs/0'));
 
-    child.exec(
-      'node --harmony-top-level-await --experimental-modules rechoir.js',
-      done
-    );
+    child.exec('node rechoir.js', done);
   });
 
   it('does not error with the .cjs extension when inside a type: commonjs package', function (done) {

--- a/test/index.js
+++ b/test/index.js
@@ -281,7 +281,7 @@ describe('interpret.extensions', function () {
   });
 
   it('does not error with the .cjs extension when inside a type: commonjs package', function (done) {
-    process.chdir(path.join(__dirname, 'fixtures/cjs/0'));
+    process.chdir(path.join(__dirname, 'fixtures/cjs/1'));
 
     child.exec('node rechoir.js', done);
   });

--- a/test/index.js
+++ b/test/index.js
@@ -4,6 +4,7 @@ var expect = require('expect');
 
 var path = require('path');
 var Module = require('module');
+var child = require('child_process');
 var shell = require('shelljs');
 var rechoir = require('rechoir');
 
@@ -69,8 +70,8 @@ describe('interpret.extensions', function () {
       return attempts;
     }
 
-    // We will handle the .mjs tests separately
-    if (ext === '.mjs') {
+    // We will handle the .mjs & .cjs tests separately
+    if (ext === '.mjs' || ext === '.cjs') {
       return attempts;
     }
 
@@ -267,5 +268,17 @@ describe('interpret.extensions', function () {
     };
     expect(require(fixture)).toEqual(expected);
     done();
+  });
+
+  it('does not error with the .cjs extension when inside a type: module package', function (done) {
+    process.chdir(path.join(__dirname, 'fixtures/cjs/0'));
+
+    child.exec('node rechoir.js', done);
+  });
+
+  it('does not error with the .cjs extension when inside a type: commonjs package', function (done) {
+    process.chdir(path.join(__dirname, 'fixtures/cjs/0'));
+
+    child.exec('node rechoir.js', done);
   });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -271,13 +271,9 @@ describe('interpret.extensions', function () {
   });
 
   it('does not error with the .cjs extension when inside a type: module package', function (done) {
-    if (nodeVersion.major < 12) {
-      this.skip();
-    }
-
     process.chdir(path.join(__dirname, 'fixtures/cjs/0'));
 
-    child.exec('node rechoir.js', done);
+    child.exec('node --harmony-top-level-await --experimental-modules rechoir.js', done);
   });
 
   it('does not error with the .cjs extension when inside a type: commonjs package', function (done) {


### PR DESCRIPTION
When using `type="module"`, there's still the ability to use `commonjs` style `require` and `module.exports` in `.cjs` files (as opposed to `.js` files).

This PR adds it as a candidate for files that can be handled using Liftoff

I've tested this within our close-to-release [`plopjs@3`](https://github.com/plopjs/plop/tree/esm) release, which will support ESM