### PR TITLE
feat: Leverage endsWith instead of RegExp in matchers

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 var path = require('path');
 
 // We only register on the final extension (like `.js`) due to https://github.com/joyent/node/blob/v0.12.0/lib/module.js#L353
-// which only captures the final extension (.esm.js -> .js)
 // However, we use these matchers to apply the transform only if the full extension matches
 function endsInJsx(filename) {
   return filename.endsWith('.jsx');

--- a/index.js
+++ b/index.js
@@ -1,27 +1,46 @@
 var path = require('path');
 
-var endsInJsx = /\.jsx$/;
-var endsInTs = /\.ts$/;
-var endsInTsx = /\.tsx$/;
-var endsInBabelJs = /\.babel\.js$/;
-var endsInBabelJsx = /\.babel\.jsx$/;
-var endsInBabelTs = /\.babel\.ts$/;
-var endsInBabelTsx = /\.babel\.tsx$/;
-var endsInEsbuildJs = /\.esbuild\.js$/;
-var endsInEsbuildJsx = /\.esbuild\.jsx$/;
-var endsInEsbuildTs = /\.esbuild\.ts$/;
-var endsInEsbuildTsx = /\.esbuild\.tsx$/;
+// We only register on the final extension (like `.js`) due to https://github.com/joyent/node/blob/v0.12.0/lib/module.js#L353
+// which only captures the final extension (.esm.js -> .js)
+// However, we use these matchers to apply the transform only if the full extension matches
+function endsInJsx(filename) {
+  return filename.endsWith('.jsx');
+}
+function endsInTs(filename) {
+  return filename.endsWith('.ts');
+}
+function endsInTsx(filename) {
+  return filename.endsWith('.tsx');
+}
+function endsInBabelJs(filename) {
+  return filename.endsWith('.babel.js');
+}
+function endsInBabelJsx(filename) {
+  return filename.endsWith('.babel.jsx');
+}
+function endsInBabelTs(filename) {
+  return filename.endsWith('.babel.ts');
+}
+function endsInBabelTsx(filename) {
+  return filename.endsWith('.babel.tsx');
+}
+function endsInEsbuildJs(filename) {
+  return filename.endsWith('.esbuild.js');
+}
+function endsInEsbuildJsx(filename) {
+  return filename.endsWith('.esbuild.jsx');
+}
+function endsInEsbuildTs(filename) {
+  return filename.endsWith('.esbuild.ts');
+}
+function endsInEsbuildTsx(filename) {
+  return filename.endsWith('.esbuild.tsx');
+}
 
 var mjsStub = path.join(__dirname, 'mjs-stub');
 
-// Not part of the above check because it seems broken
 function isNodeModules(file) {
-  return (
-    path
-      .relative(process.cwd(), file)
-      .split(path.sep)
-      .indexOf('node_modules') >= 0
-  );
+  return path.relative(process.cwd(), file).includes('node_modules');
 }
 
 var extensions = {
@@ -75,9 +94,7 @@ var extensions = {
       mod.register({
         extensions: ['.js'],
         target: 'node' + process.version.slice(1),
-        hookMatcher: function (file) {
-          return endsInEsbuildJs.test(file);
-        },
+        hookMatcher: endsInEsbuildJs
       });
     },
   },
@@ -87,9 +104,7 @@ var extensions = {
       mod.register({
         extensions: ['.jsx'],
         target: 'node' + process.version.slice(1),
-        hookMatcher: function (file) {
-          return endsInEsbuildJsx.test(file);
-        },
+        hookMatcher: endsInEsbuildJsx
       });
     },
   },
@@ -99,9 +114,7 @@ var extensions = {
       mod.register({
         extensions: ['.ts'],
         target: 'node' + process.version.slice(1),
-        hookMatcher: function (file) {
-          return endsInEsbuildTs.test(file);
-        },
+        hookMatcher: endsInEsbuildTs
       });
     },
   },
@@ -111,9 +124,7 @@ var extensions = {
       mod.register({
         extensions: ['.tsx'],
         target: 'node' + process.version.slice(1),
-        hookMatcher: function (file) {
-          return endsInEsbuildTsx.test(file);
-        },
+        hookMatcher: endsInEsbuildTsx
       });
     },
   },
@@ -167,9 +178,7 @@ var extensions = {
         mod.register({
           extensions: ['.ts'],
           target: 'node' + process.version.slice(1),
-          hookMatcher: function (file) {
-            return endsInTs.test(file);
-          },
+          hookMatcher: endsInTs
         });
       },
     },
@@ -203,9 +212,7 @@ var extensions = {
         mod.register({
           extensions: ['.tsx'],
           target: 'node' + process.version.slice(1),
-          hookMatcher: function (file) {
-            return endsInTsx.test(file);
-          },
+          hookMatcher: endsInTsx
         });
       },
     },


### PR DESCRIPTION
This removes the RegExp matchers and instead replaces them with functions that use `endsWith`. We've mostly been trying to remove RegExp whenever possible because then people can stop flooding us with stupid ReDoS issues.