### PR TITLE
feat: Support `.mdx` extension hook

### DIFF
--- a/index.js
+++ b/index.js
@@ -177,6 +177,9 @@ var extensions = {
     'sucrase/register/jsx',
   ],
   '.litcoffee': 'coffeescript/register',
+  // The mdx loader hooks both `.md` and `.mdx` when it is imported
+  // but we only install the hook if `.mdx` is the first file
+  '.mdx': '@mdx-js/register',
   '.mjs': mjsStub,
   '.node': null,
   '.sucrase.js': {
@@ -344,6 +347,7 @@ var jsVariantExtensions = [
   '.esm.js',
   '.jsx',
   '.litcoffee',
+  '.mdx',
   '.mjs',
   '.sucrase.js',
   '.sucrase.jsx',

--- a/test/fixtures/mdx/0/package.json
+++ b/test/fixtures/mdx/0/package.json
@@ -1,0 +1,6 @@
+{
+  "dependencies": {
+    "@mdx-js/register": "^2.1.1",
+    "react": "^18.0.0"
+  }
+}

--- a/test/fixtures/mdx/0/test.mdx
+++ b/test/fixtures/mdx/0/test.mdx
@@ -1,0 +1,9 @@
+export const Thing = () => {
+  var trueKey = true;
+  var falseKey = false;
+  var subKey = { subProp: 1 };
+  // Test harmony object short notation
+  return { data: { trueKey, falseKey, subKey } };
+}
+
+<Thing />

--- a/test/index.js
+++ b/test/index.js
@@ -48,7 +48,9 @@ function cleanup() {
 }
 
 // These modules need newer node features
-var minVersions = {};
+var minVersions = {
+  '@mdx-js/register': { major: 12 }
+};
 
 var maxVersions = {};
 

--- a/test/index.js
+++ b/test/index.js
@@ -180,6 +180,21 @@ describe('interpret.extensions', function () {
             expect(require(fixture)).toEqual(expected);
             break;
 
+          case '.mdx':
+            expected = {
+              data: {
+                trueKey: true,
+                falseKey: false,
+                subKey: {
+                  subProp: 1,
+                },
+              },
+            };
+            var component = require(fixture);
+            // React internals :shrug:
+            expect(component().type()).toEqual(expected);
+            break;
+
           case '.toml':
             expected = Object.create(null);
             expected.data = Object.create(null);


### PR DESCRIPTION
Closes #84 

This adds mdx support to our loader extensions.

👋  heya @wooorm